### PR TITLE
fix(numbered_patch): accept unusual hunk headers

### DIFF
--- a/.github/workflows/llm-review.yml
+++ b/.github/workflows/llm-review.yml
@@ -12,7 +12,7 @@ jobs:
       pull-requests: write
     steps:
       - name: LLM PR Review
-        uses: TensorAlchemy/LLM-Reviewer@fix/numbered-patch
+        uses: TensorAlchemy/LLM-Reviewer@${{ github.event.pull_request.head.sha }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}

--- a/.github/workflows/llm-review.yml
+++ b/.github/workflows/llm-review.yml
@@ -12,7 +12,7 @@ jobs:
       pull-requests: write
     steps:
       - name: LLM PR Review
-        uses: TensorAlchemy/LLM-Reviewer@main
+        uses: TensorAlchemy/LLM-Reviewer@fix/numbered-patch
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}

--- a/.github/workflows/llm-review.yml
+++ b/.github/workflows/llm-review.yml
@@ -11,8 +11,13 @@ jobs:
       issues: write
       pull-requests: write
     steps:
+      - name: Checkout PR
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+
       - name: LLM PR Review
-        uses: TensorAlchemy/LLM-Reviewer@${{ github.event.pull_request.head.sha }}
+        uses: ./
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}

--- a/app/completion.py
+++ b/app/completion.py
@@ -43,6 +43,7 @@ YOU MUST NOT MENTION CHECKING CONFIGURATION. Assume a senior developer.
 YOU MUST NOT MENTION CHECKING VARIABLE REFERENCES!
 """
 
+
 class Provider(Enum):
     OPENAI = 1
     ANTHROPIC = 2
@@ -52,27 +53,27 @@ class LLMClient:
     """LLM API client"""
 
     models = {
-# commented out obsolete models:
-#        "gpt-3.5-turbo-1106": {
-#            "input_price": 1,
-#            "output_price": 2,
-#            "provider": Provider.OPENAI,
-#        },
-#        "gpt-4-1106-preview": {
-#            "input_price": 10,
-#            "output_price": 30,
-#            "provider": Provider.OPENAI,
-#        },
-#        "gpt-4-0125-preview": {
-#            "input_price": 10,
-#            "output_price": 30,
-#            "provider": Provider.OPENAI,
-#        },
-#        "gpt-4": {
-#            "input_price": 10,
-#            "output_price": 60,
-#            "provider": Provider.OPENAI,
-#        },
+        # commented out obsolete models:
+        #        "gpt-3.5-turbo-1106": {
+        #            "input_price": 1,
+        #            "output_price": 2,
+        #            "provider": Provider.OPENAI,
+        #        },
+        #        "gpt-4-1106-preview": {
+        #            "input_price": 10,
+        #            "output_price": 30,
+        #            "provider": Provider.OPENAI,
+        #        },
+        #        "gpt-4-0125-preview": {
+        #            "input_price": 10,
+        #            "output_price": 30,
+        #            "provider": Provider.OPENAI,
+        #        },
+        #        "gpt-4": {
+        #            "input_price": 10,
+        #            "output_price": 60,
+        #            "provider": Provider.OPENAI,
+        #        },
         "gpt-4o": {
             "input_price": 5,
             "output_price": 15,
@@ -90,8 +91,14 @@ class LLMClient:
         },
     }
 
-    exceptions_to_retry = (openai.RateLimitError, openai.APIConnectionError, openai.InternalServerError,
-         anthropic.RateLimitError, anthropic.APIConnectionError, anthropic.InternalServerError)
+    exceptions_to_retry = (
+        openai.RateLimitError,
+        openai.APIConnectionError,
+        openai.InternalServerError,
+        anthropic.RateLimitError,
+        anthropic.APIConnectionError,
+        anthropic.InternalServerError,
+    )
 
     def __init__(
         self,
@@ -132,7 +139,7 @@ class LLMClient:
                 },
             ],
             temperature=self.temperature,
-            response_format={ "type": "json_object" }
+            response_format={"type": "json_object"},
         )
         content = response.choices[0].message.content
         cost = self.calculate_cost(
@@ -157,9 +164,9 @@ class LLMClient:
                             "type": "text",
                             "text": prompt,
                         }
-                    ]
+                    ],
                 }
-            ]
+            ],
         )
         content = response.content[0].text
         cost = self.calculate_cost(response.usage)
@@ -244,11 +251,13 @@ EXAMPLE:
 if __name__ == "__main__":
     for model in "gpt-4o-mini", "claude-3-5-sonnet-20240620":
         cli = LLMClient(model=model, temperature=0.2)
-        prompt = cli.get_pr_prompt("""
+        prompt = cli.get_pr_prompt(
+            """
 @@ -1,1 +1,1 @@
 -print(f"The answer is {42}")
 +print("The answer is " + 42)
-""")
+"""
+        )
         content, cost = cli.get_completion(prompt)
         print(model)
         print(content)

--- a/app/main.py
+++ b/app/main.py
@@ -23,7 +23,9 @@ if not os.getenv("OPENAI_API_KEY") and not os.getenv("ANTHROPIC_API_KEY"):
 parser = argparse.ArgumentParser(
     description="Automated pull requests reviewing and issues triaging with an LLM"
 )
-parser.add_argument("--model", help="LLM model", type=str, default="claude-3-5-sonnet-20240620")
+parser.add_argument(
+    "--model", help="LLM model", type=str, default="claude-3-5-sonnet-20240620"
+)
 parser.add_argument(
     "--temperature", help="Temperature for the model", type=float, default=0.2
 )

--- a/app/numbered_patch.py
+++ b/app/numbered_patch.py
@@ -1,0 +1,133 @@
+import re
+
+""" Add line numbers to a patch file for the LLM """
+
+
+def number_lines_in_patch(changes: str) -> str:
+    """Add line numbers to a patch file for the LLM"""
+    lines = changes.split("\n")
+    numbered_lines = []
+    current_line_number = None
+    in_hunk = False
+
+    for line in lines:
+        if in_hunk and is_end_of_hunk(line):
+            in_hunk = False
+            current_line_number = None
+
+        if in_hunk:
+            if line.startswith("-"):
+                line = f"\t{line}"
+            else:
+                current_line_number += 1
+                line = f"{current_line_number}\t{line}"
+
+        if line.startswith("@@"):
+            in_hunk = True
+            current_line_number = parse_hunk_header(line)
+        numbered_lines.append(line)
+
+    return "\n".join(numbered_lines)
+
+
+def parse_hunk_header(header: str) -> int:
+    match = re.match(r"@@ -\d+(,\d+)? \+(\d+)(,\d+)? @@", header)
+    if not match:
+        raise ValueError(f"Invalid hunk header: {header}")
+    return int(match.group(2)) - 1
+
+
+def is_end_of_hunk(line: str) -> None:
+    return not re.match(r"[ +-]", line)
+
+
+def test_number_lines_in_patch_add_code():
+    input_text = """diff --git a/hello.py b/hello.py
+new file mode 100755
+index 0000000..5dc9fd1
+--- /dev/null
++++ b/hello.py
+@@ -0,0 +1,3 @@
++#!/usr/bin/env python
++
++print("Hello, world")
+"""
+    expected_output = """diff --git a/hello.py b/hello.py
+new file mode 100755
+index 0000000..5dc9fd1
+--- /dev/null
++++ b/hello.py
+@@ -0,0 +1,3 @@
+1\t+#!/usr/bin/env python
+2\t+
+3\t+print("Hello, world")
+"""
+    assert number_lines_in_patch(input_text) == expected_output
+
+
+def test_number_lines_in_patch_remove_line():
+    input_text = """
+diff --git a/foo/__init__.py b/foo/__init__.py
+index 01234567..01234567 100644
+--- a/foo/__init__.py
++++ b/foo/__init__.py
+@@ -1 +0,0 @@
+-
+"""
+    expected_output = """
+diff --git a/foo/__init__.py b/foo/__init__.py
+index 01234567..01234567 100644
+--- a/foo/__init__.py
++++ b/foo/__init__.py
+@@ -1 +0,0 @@
+\t-
+"""
+    assert number_lines_in_patch(input_text) == expected_output
+
+
+def test_number_lines_in_patch_replace_code():
+    input_text = """diff --git a/hello.py b/hello.py
+index 5dc9fd1..54f6661 100644
+--- a/hello.py
++++ b/hello.py
+@@ -1,3 +1,5 @@
+-#!/usr/bin/env python
++import sys
+ 
+ print("Hello, world")
++
++sys.exit(0)
+"""
+    expected_output = """diff --git a/hello.py b/hello.py
+index 5dc9fd1..54f6661 100644
+--- a/hello.py
++++ b/hello.py
+@@ -1,3 +1,5 @@
+\t-#!/usr/bin/env python
+1\t+import sys
+2\t 
+3\t print("Hello, world")
+4\t+
+5\t+sys.exit(0)
+"""
+    assert number_lines_in_patch(input_text) == expected_output
+
+
+def test_number_lines_in_patch_add_single_line():
+    input_text = """diff --git a/test.py b/test.py
+new file mode 100644
+index 0000000..11b15b1
+--- /dev/null
++++ b/test.py
+@@ -0,0 +1 @@
++print("hello")
+"""
+    expected_output = """diff --git a/test.py b/test.py
+new file mode 100644
+index 0000000..11b15b1
+--- /dev/null
++++ b/test.py
+@@ -0,0 +1 @@
+1\t+print("hello")
+"""
+    assert number_lines_in_patch(input_text) == expected_output


### PR DESCRIPTION
- Fix parse_hunk_header to accept unusual hunk headers:
  @@ -1,3 +1,5 @@     # a normal hunk header, with 4 numbers
  @@ -1 +0,0 @@       # single source line number
  @@ -0,0 +1 @@       # single target line number
- Move line numbering logic from githubs.py to new numbered_patch.py module
- Add tests in numbered_patch.py
- reformat all files with black